### PR TITLE
Delete reference to Gerrithub, all downloads now go through Github.

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -3,9 +3,7 @@
 Harvey is currently under very active development, to the point that
 a release could just become obsolete overnight.
 
-For source code access, you should go to our [github page](https://github.com/Harvey-OS/harvey)
-or go see [gerrithub.io](https://review.gerrithub.io/#/admin/projects/Harvey-OS/harvey)
-for code review.
+For source code access, you should go to our [github page](https://github.com/Harvey-OS/harvey).
 
 [![Build Status](https://travis-ci.org/Harvey-OS/harvey.svg?branch=master)](https://travis-ci.org/Harvey-OS/harvey)
 [![Coverity Badge](https://scan.coverity.com/projects/5328/badge.svg)](https://scan.coverity.com/projects/5328)


### PR DESCRIPTION
Updating info on the web about the new Github-centric setup.
