### PR TITLE
No webfonts, prioritize content.

### DIFF
--- a/barehare_theme/base.html
+++ b/barehare_theme/base.html
@@ -85,11 +85,19 @@
         {% if not page_title %}
           <h1>{{ site_name }}</h1>
           <p class="tagline"> ~ {{ page_description }}</p>
-          <img id="logo" src="img/harvey-os-logo.svg" alt="Harvey logo" title="Harvey logo" />
         {% endif %}
 
             {{content}}
+
         </article>
+
+        {% if not page_title %}
+        <aside>
+        <img id="logo" src="img/harvey-os-logo.svg" alt="Harvey OS logo" title="Hi! You look good today." />
+        </aside
+        {% endif %}
+
+
 
         {% block toc %}
           {% if page_title in config.extra.toc_pages %}
@@ -118,18 +126,6 @@
 
 <!--  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css"> -->
 <!--  <link rel="stylesheet" href="{{ base_url }}/css/harvey.min.css"> -->
-
-  <link href='https://fonts.googleapis.com/css?family=Open+Sans|Roboto+Condensed:400,700' rel='stylesheet' type='text/css'>
-
-  <script type="text/javascript" src="{{ base_url }}/js/fontfaceobserver.js"></script>
-
-  <script type="text/javascript">
-    var observer = new FontFaceObserver('Open Sans', {weight: 400});
-
-    observer.check().then( function(){
-            document.documentElement.className += " fonts-loaded";
-        });
-  </script>
 
 
   <script type="text/javascript">

--- a/barehare_theme/inline-styles.html
+++ b/barehare_theme/inline-styles.html
@@ -7,11 +7,10 @@ body {
   color: #111;
   margin: 0;
   padding: 0;
-  /* font-family: 'Open Sans', sans-serif; */
-  font-family: sans-serif;
+  font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+  letter-spacing: -0.001em;
 }
 
-.fonts-loaded body { font-family: 'Open Sans', sans-serif; }
 
 .flexer {
   display: flex;
@@ -21,13 +20,13 @@ body {
 
 ::selection {background-color:#eb6864; color:#fff;}
 
-h1,h2,h3,h4 {font-family: 'Roboto Condensed', sans-serif; color: #555; font-weight: 400;}
+h1,h2,h3,h4 { color: #555; font-weight: 500; letter-spacing: -0.008em; }
 
-h1 {font-size: 2.2em; display: none; color: #000;}
+h1 {font-size: 2.2em; display: none; color: #000; text-shadow: 0 0 1px rgba(0, 0, 0, 0.3);}
 h2 {font-size: 1.8em;}
 h3 {font-size: 1.4em;}
 
-a { color: #eb6864; text-decoration:none; padding: .3em;}
+a { color: #eb6864; text-decoration:none; padding: .2em;}
 a:hover {background-color: #eb6864; color: white;}
 
 p { text-align: left; }
@@ -36,8 +35,8 @@ p { text-align: left; }
 /* NAVBAR STYLES */
 
 nav { margin: 0; }
-nav a {display: block; color: white;}
-nav a:hover { /* color: white; */border-bottom: none;}
+nav a {display: block; color: white; }
+nav a:hover { border-bottom: none;}
 
 .toggle + a, .menu { display: none; }
 
@@ -56,11 +55,6 @@ nav a:hover { /* color: white; */border-bottom: none;}
 .toggle-brand a { display: inline; font-size: 1em; padding:0;}
 .toggle-brand a:hover { background: transparent; color: #eb6864;}
 
-/*
-.burger {float: right; padding:0 0.7em;}
-.burger:hover, .burger:active {background-color: #eb6864;}
-.burger:after { content: " "; clear: both;}
-*/
 
 .burger {
     position: absolute;
@@ -92,8 +86,9 @@ label.burger:active { background-color: #eb6864;}
 
 
 .menu > li { display: block; border-bottom: 1px solid #eee; padding: 0;}
-.menu li:hover,
+.menu li:hover {background-color: #eb6864;}
 .menu li.active {background-color: #eee;}
+.menu li:last-child {border-bottom: 1px solid #ccc;}
 .menu a { display: block; text-decoration: none; color: #000; padding: 1em; }
 .menu a:hover { color: white; }
 
@@ -107,12 +102,14 @@ label.burger:active { background-color: #eb6864;}
 
 .container { display: flex; flex-flow: column wrap; flex: 1 0 auto; width: 100%;}
 
-main { order: 1;}
+main { display: flex; order: 1;}
 aside { order: 2; margin-top: 4em;}
 main, aside { padding: 0 1em;}
 
 img { max-width: 100%; height: auto; width: auto\9; /* ie8 */ }
 
+main.with-toc {display: flex; flex-flow: column wrap;}
+.with-toc img { width: 100%;}
 
 .news article p a { padding: 0;}
 
@@ -136,8 +133,9 @@ footer {
 
 footer p { padding:0 ; margin-top: .7em; text-align: center;}
 
-.container.homepage #logo { float: right; max-width: 30%; margin: .5em .2em 0 .5em; }
+.container.homepage #logo { float: right; margin: .5em -.5em 0 1em; }
 .container.homepage h2 { margin: 0; padding: .2em 0; }
+.container.homepage aside { margin: 0; padding: 0; }
 
 .lazy img { margin: .5em 1.5em 0 0;}
 .lazy a:hover { background: transparent; }
@@ -156,7 +154,7 @@ footer p { padding:0 ; margin-top: .7em; text-align: center;}
   .extra svg:hover { fill: #eb6864;}
   .extra:after { content: " "; clear: both; }
 
-  .container.homepage #logo { margin: 1.6em .2em 0 1em; }
+  .container.homepage #logo { margin: .5em .5em 0 1em; }
 
   .lazy img { margin: .5em .5em 0 0;}
 }
@@ -164,16 +162,16 @@ footer p { padding:0 ; margin-top: .7em; text-align: center;}
 
 
 
-/* Large screens - 1025px */
+/* Large screens - 1024px */
 @media only screen and (min-width: 64em) {
 
 
   nav {
     padding: 0 5%;
     border-bottom: 1px solid #eee;
-    font-family: 'Roboto Condensed', sans-serif;
-    font-size: 1.1em;
-    line-height: 1.1em;
+    font-size: 1em;
+    line-height: 1em;
+    font-weight: 400;
   }
 
   nav a {display: inline-block; color: initial; padding:0;}
@@ -192,6 +190,9 @@ footer p { padding:0 ; margin-top: .7em; text-align: center;}
 
   /* Level 1 */
   .menu > li { display: inline-flex; border-bottom: none;}
+  .menu li:hover,
+  .menu li.active {background-color: #eee;}
+  .menu li:last-child {border-bottom: none;}
   .menu a { display: block; text-decoration: none; color: #000; padding: .7em 1.3em; }
   .menu a:hover { color: inherit;}
 
@@ -206,9 +207,11 @@ footer p { padding:0 ; margin-top: .7em; text-align: center;}
   aside h3 {padding-bottom: 1em; margin:0;}
   aside ul {padding: 0 0 0 1em; margin:0;}
 
+  main.with-toc {display: flex; flex-flow: row nowrap; width: 70%;}
 
   .container.homepage  { margin-top: 2em; flex: 1; }
   .container.homepage h1 { margin: 0 0 1.5em 0; padding:0; display: inline-block;}
+  .container.homepage aside { max-width: 100%; width:initial; }
   .container.homepage #logo { float: right; margin: 6.5em 0 0 1em; max-width: 100%;}
 
   h1 { display: block; margin-bottom: 1.2em;}
@@ -237,3 +240,10 @@ footer p { padding:0 ; margin-top: .7em; text-align: center;}
 }
 
 </style>
+
+<!--[if IE]>
+<style>
+    body { text-shadow: 0 0 1px rgba(1, 1, 1, 0.3); }
+</style>
+<![endif]-->
+


### PR DESCRIPTION
- Take out webfonts css import and fontfaceobserver.js (1)
- Changes to the font stack ("Arial, Helvetica, sans-serif") (1)
- Adjust letter spacing (so system font is not as wide) (1)
- Move homepage logo to an aside after the article (2)
- .with-toc class is now display:flex (2)
- Images in "News" grow to fill screen width
- Delete some unused styles
